### PR TITLE
fix: support ModuleType targets and use find_spec instead of import_module

### DIFF
--- a/objwatch/core.py
+++ b/objwatch/core.py
@@ -2,7 +2,8 @@
 # Copyright (c) 2025 aeeeeeep
 
 import logging
-from typing import List, Optional, Any
+from types import ModuleType
+from typing import Optional, Union, List, Any
 from .tracer import Tracer
 from .wrappers import FunctionWrapper
 from .utils.logger import create_logger, log_info
@@ -15,8 +16,8 @@ class ObjWatch:
 
     def __init__(
         self,
-        targets: List[str],
-        exclude_targets: Optional[List[str]] = None,
+        targets: List[Union[str, ModuleType]],
+        exclude_targets: Optional[List[Union[str, ModuleType]]] = None,
         ranks: Optional[List[int]] = None,
         output: Optional[str] = None,
         output_xml: Optional[str] = None,
@@ -30,8 +31,8 @@ class ObjWatch:
         Initialize the ObjWatch instance with configuration parameters.
 
         Args:
-            targets (List[str]): Files or modules to monitor.
-            exclude_targets (Optional[List[str]]): Files or modules to exclude from monitoring.
+            targets (List[Union[str, ModuleType]]): Files or modules to monitor.
+            exclude_targets (Optional[List[Union[str, ModuleType]]]): Files or modules to exclude from monitoring.
             ranks (Optional[List[int]]): GPU ranks to track when using torch.distributed.
             output (Optional[str]): Path to a file for writing logs.
             output_xml (Optional[str]): Path to the XML file for writing structured logs.
@@ -104,8 +105,8 @@ class ObjWatch:
 
 
 def watch(
-    targets: List[str],
-    exclude_targets: Optional[List[str]] = None,
+    targets: List[Union[str, ModuleType]],
+    exclude_targets: Optional[List[Union[str, ModuleType]]] = None,
     ranks: Optional[List[int]] = None,
     output: Optional[str] = None,
     output_xml: Optional[str] = None,
@@ -119,8 +120,8 @@ def watch(
     Initialize and start an ObjWatch instance.
 
     Args:
-        targets (List[str]): Files or modules to monitor.
-        exclude_targets (Optional[List[str]]): Files or modules to exclude from monitoring.
+        targets (List[Union[str, ModuleType]]): Files or modules to monitor.
+        exclude_targets (Optional[List[Union[str, ModuleType]]]): Files or modules to exclude from monitoring.
         ranks (Optional[List[int]]): GPU ranks to track when using torch.distributed.
         output (Optional[str]): Path to a file for writing logs.
         output_xml (Optional[str]): Path to the XML file for writing structured logs.

--- a/tests/test.py
+++ b/tests/test.py
@@ -369,7 +369,7 @@ class TestCustomWrapper(unittest.TestCase):
             self.logger.removeHandler(handler)
 
 
-class TestTracerProcessTargets(unittest.TestCase):
+class TestTracerProcessTargetsStr(unittest.TestCase):
     def test_process_targets_with_submodules(self):
         tracer = Tracer(targets=['importlib'])
         processed = tracer._process_targets(['importlib'])
@@ -378,24 +378,68 @@ class TestTracerProcessTargets(unittest.TestCase):
         self.assertIn(main_module_file, processed, "Main module file was not processed.")
 
         submodules = [
-            'importlib/metadata/_adapters.py',
-            'importlib/util.py',
-            'importlib/metadata/_meta.py',
-            'importlib/_abc.py',
             'importlib/metadata/_functools.py',
             'importlib/metadata/__init__.py',
-            'importlib/machinery.py',
-            'importlib/resources.py',
-            'importlib/_common.py',
-            'importlib/metadata/_text.py',
-            'importlib/metadata/_collections.py',
-            'importlib/_bootstrap.py',
+            'importlib/resources/simple.py',
+            'importlib/metadata/_adapters.py',
+            'importlib/resources/_adapters.py',
             'importlib/__init__.py',
-            'importlib/readers.py',
-            'importlib/_bootstrap_external.py',
+            'importlib/resources/_legacy.py',
+            'importlib/metadata/_meta.py',
+            'importlib/simple.py',
+            'importlib/resources/__init__.py',
+            'importlib/resources/readers.py',
             'importlib/metadata/_itertools.py',
-            'importlib/_adapters.py',
+            'importlib/metadata/_collections.py',
             'importlib/abc.py',
+            'importlib/_abc.py',
+            'importlib/resources/_common.py',
+            'importlib/readers.py',
+            'importlib/resources/abc.py',
+            'importlib/metadata/_text.py',
+            'importlib/resources/_itertools.py',
+        ]
+
+        for submodule_path in submodules:
+            full_path = None
+            try:
+                submodule = importlib.import_module(submodule_path.replace('/', '.').rstrip('.py'))
+                if hasattr(submodule, '__file__') and submodule.__file__:
+                    full_path = submodule.__file__
+                    self.assertIn(full_path, processed, f"Submodule {submodule_path} was not processed.")
+            except ImportError:
+                pass
+
+
+class TestTracerProcessTargetsModule(unittest.TestCase):
+    def test_process_targets_with_submodules(self):
+        tracer = Tracer(targets=[importlib])
+        processed = tracer._process_targets([importlib])
+
+        main_module_file = importlib.__file__
+        self.assertIn(main_module_file, processed, "Main module file was not processed.")
+
+        submodules = [
+            'importlib/metadata/_functools.py',
+            'importlib/metadata/__init__.py',
+            'importlib/resources/simple.py',
+            'importlib/metadata/_adapters.py',
+            'importlib/resources/_adapters.py',
+            'importlib/__init__.py',
+            'importlib/resources/_legacy.py',
+            'importlib/metadata/_meta.py',
+            'importlib/simple.py',
+            'importlib/resources/__init__.py',
+            'importlib/resources/readers.py',
+            'importlib/metadata/_itertools.py',
+            'importlib/metadata/_collections.py',
+            'importlib/abc.py',
+            'importlib/_abc.py',
+            'importlib/resources/_common.py',
+            'importlib/readers.py',
+            'importlib/resources/abc.py',
+            'importlib/metadata/_text.py',
+            'importlib/resources/_itertools.py',
         ]
 
         for submodule_path in submodules:


### PR DESCRIPTION
fix: support ModuleType targets and use find_spec instead of import_module

optimizing performance with lru_cache